### PR TITLE
make coverage and make coverage-cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 test.out
 .vscode/
 */*.swp
+coverage-*.html

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 GOPATH:=$(shell go env GOPATH)
 GRPC_LIST:=$(shell go list -m -f "{{.Dir}}" github.com/grpc-ecosystem/grpc-gateway)
 GRPC_GATEWAY_PROTO_DIR:="${GRPC_LIST}/third_party/googleapis"
+TIMESTAMP:=$(shell date -u +%s)
 
 default: fmt build
 
@@ -25,3 +26,11 @@ api/repository.swagger.json: api/repository.proto
 build: api/repository.pb.go api/repository.pb.gw.go api/repository.swagger.json
 	go test ./...
 	go build ./...
+
+coverage: api/repository.pb.go api/repository.pb.gw.go api/repository.swagger.json
+	go test -coverprofile=test.out ./...
+	go tool cover -html=test.out -o coverage-$(TIMESTAMP).html
+	echo "Coverage report: coverage-$(TIMESTAMP).html"
+
+coverage-cleanup:
+	rm test.out coverage-*.html


### PR DESCRIPTION
coverage: Generates a coverage report (in HTML) to inspect test coverage
of code and to share with collaborators if desired.

coverage-cleanup: Cleans up files generated by make coverage --
currently, it cleans up ALL coverage HTML reports in the directory
(following the glob pattern coverage-*.html).