### PR TITLE
Enforce non-null fields in model and hyperparameters creation

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -174,8 +174,14 @@ func (srv *server) GetModel(ctx context.Context, req *api.GetModelRequest) (*api
 func (srv *server) CreateModel(ctx context.Context, req *api.CreateModelRequest) (*api.CreateModelResponse, error) {
 	model := req.Model
 	log.Printf("CreateModel request - Model: %v", model)
+	// Check that ModelId is a non-empty string
 	if !IsValidID(model.ModelId) {
 		grpcErr := status.Error(codes.InvalidArgument, "ModelId was invalid")
+		return nil, grpcErr
+	}
+	// Check that Details field in request model is not nil
+	if model.Details == "" {
+		grpcErr := status.Error(codes.InvalidArgument, "Details should be specified in CreateModel request")
 		return nil, grpcErr
 	}
 	storageModel := storage.Model{

--- a/server/server.go
+++ b/server/server.go
@@ -275,6 +275,11 @@ func (srv *server) ListHyperparameters(ctx context.Context, req *api.ListHyperpa
 func (srv *server) CreateHyperparameters(ctx context.Context, req *api.CreateHyperparametersRequest) (*api.CreateHyperparametersResponse, error) {
 	modelID := req.ModelId
 	hyperparametersID := req.HyperparametersId
+	// Check that ModelId and HyperparametersId in request are valid IDs.
+	if !IsValidID(modelID) {
+		grpcErr := status.Error(codes.InvalidArgument, "modelID is invalid")
+		return nil, grpcErr
+	}
 	if !IsValidID(hyperparametersID) {
 		grpcErr := status.Error(codes.InvalidArgument, "hyperparametersID is invalid")
 		return nil, grpcErr

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -993,7 +993,7 @@ func TestURLEndpoints(t *testing.T) {
 		postRequest(t, baseUrl+"models",
 			map[string]interface{}{"model": map[string]string{
 				"modelId":                  "MyModel",
-				"description":              "Selfie model",
+				"details":                  "Selfie model",
 				"canonicalHyperparameters": "batch-666",
 				"randomTag":                "RandomValue",
 			}}, http.StatusOK))
@@ -1002,7 +1002,7 @@ func TestURLEndpoints(t *testing.T) {
 		postRequest(t, baseUrl+"models",
 			map[string]interface{}{"model": map[string]string{
 				"modelId":                  "BasicModel",
-				"description":              "Basic model",
+				"details":                  "Basic model",
 				"canonicalHyperparameters": "batch-123",
 			}}, http.StatusOK))
 


### PR DESCRIPTION
Fixes https://github.com/doc-ai/tensorio-models/issues/79

Does not enforce that `hyperparameters` field on `CreateHyperparameters` request is null. We can add this later if we wish.