### PR TITLE
Modifies helm chart to allow deployment of GCS backed repository server

### DIFF
--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -24,9 +24,22 @@ spec:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.deployment.repository }}:{{ .Values.deployment.tag }}"
           imagePullPolicy: {{ .Values.deployment.pullPolicy }}
+          volumeMounts:
+            {{- if .Values.deployment.serviceAccount }}
+            - name: sacred
+              mountPath: {{ .Values.deployment.serviceAccount.mountPath }}
+            {{- end }}
           env:
             - name: BACKEND
               value: {{ .Values.deployment.backend }}
+            {{- if .Values.deployment.repositoryGcsBucket }}
+            - name: REPOSITORY_GCS_BUCKET
+              value: {{ .Values.deployment.repositoryGcsBucket }}
+            {{- end }}
+            {{- if .Values.deployment.serviceAccount }}
+            - name: GOOGLE_APPLICATION_CREDENTIALS
+              value: "{{ .Values.deployment.serviceAccount.mountPath }}/{{ .Values.deployment.serviceAccount.key }}"
+            {{- end }}
           args: ["-backend", "$(BACKEND)"]
           ports:
             - name: grpc
@@ -43,3 +56,9 @@ spec:
             httpGet:
               path: /v1/repository/healthz
               port: rest
+      volumes:
+        {{- if .Values.deployment.serviceAccount }}
+        - name: sacred
+          secret:
+            secretName: {{ .Values.deployment.serviceAccount.secret }}
+        {{- end }}

--- a/helm/values.gcs.yaml
+++ b/helm/values.gcs.yaml
@@ -1,0 +1,24 @@
+# This values file shows how to configure tensorio-models to use a GCS backend.
+# The service account whose credentials are available under the sacred.json key of the
+# tensorio-models secret is assumed to have administrative access to the
+# .Values.deployment.repositoryGcsBucket bucket.
+
+namespace: default
+
+deployment:
+  replicas: 1
+  repository: docai/tensorio-models
+  tag: latest
+  pullPolicy: Always
+  backend: memory
+  serviceAccount:
+    secret: tensorio-models
+    key: sacred.json
+    mountPath: /etc/auth
+  repositoryGcsBucket: tensorio-models-backend-dev
+
+service:
+  type: ClusterIP
+  grpcPort: 7316
+  restPort: 7317
+  hostname: tensorio-models.default

--- a/helm/values.gcs.yaml
+++ b/helm/values.gcs.yaml
@@ -10,7 +10,7 @@ deployment:
   repository: docai/tensorio-models
   tag: latest
   pullPolicy: Always
-  backend: memory
+  backend: gcs
   serviceAccount:
     secret: tensorio-models
     key: sacred.json


### PR DESCRIPTION
Fixes https://github.com/doc-ai/tensorio-models/issues/103

This has been tested on `experimental` cluster -- checked both `memory` backend (with old `values.yaml` structure) and `gcs` backend (with new `values.yaml` structure).

The `e2e/setup.sh` script is working well against both kinds of deployments.